### PR TITLE
Fixed 'NullReferenceException' when no hash algorithm is specified for 'export-key' command.

### DIFF
--- a/src/AppCore.SigningTool/Commands/Sn/SnExportPublicKeyCommand.cs
+++ b/src/AppCore.SigningTool/Commands/Sn/SnExportPublicKeyCommand.cs
@@ -39,8 +39,11 @@ namespace AppCore.SigningTool.Commands.Sn
                 .OnValidate(
                     vc =>
                     {
-                        if (ParseAssemblyHashAlgorithm(_hashAlgorithm.ParsedValue) == AssemblyHashAlgorithm.None)
+                        if (_hashAlgorithm.HasValue()
+                            && ParseAssemblyHashAlgorithm(_hashAlgorithm.ParsedValue) == AssemblyHashAlgorithm.None)
+                        {
                             return new ValidationResult($"Unknown hash algorithm '{_hashAlgorithm.ParsedValue}'.");
+                        }
 
                         return ValidationResult.Success;
                     });


### PR DESCRIPTION
Fixes issue #5 